### PR TITLE
hotfix: Fixed the text of an action

### DIFF
--- a/input/assets/js/main.js
+++ b/input/assets/js/main.js
@@ -149,6 +149,7 @@ $("ul#bzoom").each( function(index, ul) {
 // Toggle hidden/sliced description
 $(function() {
     var hiddenDescription = $('p.pdp-product-description');
+    var generatedHidden, hiddenFlag;
 
     hiddenDescription.each(function(){
         var t = $(this).text();
@@ -157,10 +158,15 @@ $(function() {
             t.slice(0,100)+'<span>... </span>'+
             '<span class="hidden">'+ t.slice(100,t.length)+'</span>'
         );
+        generatedHidden = $('.hidden', hiddenDescription);
     });
 
     $('.view-details').click(function() {
-      $('.pdp-product-description span').toggleClass('hidden');
+        if (generatedHidden && generatedHidden.length) {
+            hiddenFlag = !!generatedHidden.hasClass('hidden');
+            $(this).text(hiddenFlag ? 'Hide details' : 'View details');
+            generatedHidden.toggleClass('hidden');
+        }
     });
 });
 

--- a/input/assets/js/main.js
+++ b/input/assets/js/main.js
@@ -148,23 +148,26 @@ $("ul#bzoom").each( function(index, ul) {
 
 // Toggle hidden/sliced description
 $(function() {
-    var hiddenDescription = $('p.pdp-product-description');
-    var generatedHidden, hiddenFlag;
+    var hiddenDescription = $('p.pdp-product-description'),
+        generatedHidden,
+        shownFlag,
+        hiddenDescriptionText;
 
-    hiddenDescription.each(function(){
-        var t = $(this).text();
-        if(t.length < 100) return;
-        $(this).html(
-            t.slice(0,100)+'<span>... </span>'+
-            '<span class="hidden">'+ t.slice(100,t.length)+'</span>'
+    if (hiddenDescription.length) {
+        hiddenDescription = hiddenDescription.first();
+        hiddenDescriptionText = hiddenDescription.text();
+
+        if (hiddenDescriptionText.length < 100) return;
+        hiddenDescription.html(
+            hiddenDescriptionText.slice(0,100)+'<span>... </span>'+
+            '<span class="hidden">'+ hiddenDescriptionText.slice(100, hiddenDescriptionText.length)+'</span>'
         );
         generatedHidden = $('.hidden', hiddenDescription);
-    });
-
+    }
     $('.view-details').click(function() {
         if (generatedHidden && generatedHidden.length) {
-            hiddenFlag = !!generatedHidden.hasClass('hidden');
-            $(this).text(hiddenFlag ? 'Hide details' : 'View details');
+            shownFlag = !!generatedHidden.hasClass('hidden');
+            $(this).text(shownFlag ? 'Hide details' : 'View details');
             generatedHidden.toggleClass('hidden');
         }
     });


### PR DESCRIPTION
- Changed the title of details action (hide/view) when toggling
- `$('.pdp-product-description span').toggleClass('hidden');` should throw an error if `span` is missing a context, so I pushed this up to a cached object only to be then evaluated if it has been generated or not depending on how the slicing went (L154)

---

__In need of more fix__

__DX__:  `hiddenDescription.each` indicates that it is expected that there are multiple `hiddenDescription` nodes within the dom to be traversed. If this were the case then `generatedHidden` needs more context  as in index of which `'p.pdp-product-description'` that it refers