### PR TITLE
Missing feature: default payment method

### DIFF
--- a/input/assets/js/main.js
+++ b/input/assets/js/main.js
@@ -244,7 +244,7 @@ $( "#different-billing-checkbox" ).click(function() {
 /*****************************************************************************/
 
 // Show credit card input fields only on 'credit card' selected
-$(function($jq) {
+$(function() {
   function setupPaymentListener() {
     $('.payment-text').change(function() {
       if($('#payment-type-credit-card').is(':checked')) {
@@ -254,6 +254,7 @@ $(function($jq) {
       }
     });
   }
-  $jq('#payment-type-credit-card').prop('checked', true);
+  
+  $('#payment-type-credit-card').prop('checked', true);
   setTimeout(setupPaymentListener, 0);
 });

--- a/input/assets/js/main.js
+++ b/input/assets/js/main.js
@@ -244,12 +244,16 @@ $( "#different-billing-checkbox" ).click(function() {
 /*****************************************************************************/
 
 // Show credit card input fields only on 'credit card' selected
-$('#credit-card-input-field').hide();
-
-$('.payment-text').change(function() {
-  if($('#payment-type-credit-card').is(':checked')) {
-    $('#credit-card-input-field').show();
-  } else {
-    $('#credit-card-input-field').hide();
+$(function($jq) {
+  function setupPaymentListener() {
+    $('.payment-text').change(function() {
+      if($('#payment-type-credit-card').is(':checked')) {
+        $('#credit-card-input-field').show();
+      } else {
+        $('#credit-card-input-field').hide();
+      }
+    });
   }
-})
+  $jq('#payment-type-credit-card').prop('checked', true);
+  setTimeout(setupPaymentListener, 0);
+});


### PR DESCRIPTION
At the checkout payment page, no option is chosen as default for the user.
![img](https://copy.com/thumbs_public/EkAlHrXBu7dG9jYS/sphere-sunrise-alignment-fix/checkout-missing-feature-1.png?size=1024)

I added this feature to enhance ux a bit

