### PR TITLE
Rename 'name' to 'label' in selectable data

### DIFF
--- a/input/templates/partials/catalog/display-selector.hbs
+++ b/input/templates/partials/catalog/display-selector.hbs
@@ -2,7 +2,7 @@
 <div class="custom-select-wrapper">
 	<select name="{{displaySelector.key}}" class="select-product-detail" required>
 	  {{#each displaySelector.list}}
-	    <option value="{{value}}" {{#if selected}}selected{{/if}}>{{name}}</option>
+	    <option value="{{value}}" {{#if selected}}selected{{/if}}>{{label}}</option>
 	  {{/each}}
 	</select>
 </div>

--- a/input/templates/partials/catalog/display-selector.json
+++ b/input/templates/partials/catalog/display-selector.json
@@ -1,17 +1,17 @@
 {
 	"list" : [
 		{
-			"name" : "12",
+			"label" : "12",
 			"value" : "12",
 			"selected" : false
 		},
 		{
-			"name" : "24",
+			"label" : "24",
 			"value" : "24",
 			"selected" : true
 		},
 		{
-			"name" : "48",
+			"label" : "48",
 			"value" : "48",
 			"selected" : false
 		}

--- a/input/templates/partials/catalog/sort-selector.hbs
+++ b/input/templates/partials/catalog/sort-selector.hbs
@@ -1,5 +1,5 @@
 <select name="{{content.sortSelector.key}}" class="select-product-detail" required>
 {{#each sortSelector.list}}
-  <option value="{{value}}" {{#if selected}}selected{{/if}}>{{text}}</option>
+  <option value="{{value}}" {{#if selected}}selected{{/if}}>{{label}}</option>
 {{/each}}
 </select>

--- a/input/templates/partials/catalog/sort-selector.json
+++ b/input/templates/partials/catalog/sort-selector.json
@@ -1,12 +1,12 @@
 {
 	"list" : [
 		{
-			"text" : "Sort by: low",
+			"label" : "Sort by: low",
 			"value" : "",
 			"selected" : false
 		},
 		{
-			"text" : "Sort by high",
+			"label" : "Sort by high",
 			"value" : "",
 			"selected" : true
 		}


### PR DESCRIPTION
When it comes to options, you usually have key (the query parameter), value (what you send along the key) and label (what you see). It is already like this for many others, so I guessed we should unify it.

@jayS-de @schleichardt @JulianSamarjiev check it doesn't affect you much.