### PR TITLE
Remove result summary

### DIFF
--- a/input/templates/partials/catalog/pagination.json
+++ b/input/templates/partials/catalog/pagination.json
@@ -1,6 +1,4 @@
 {
-	"currentPage" : 145,
-	"totalPages" : 234,
 	"previousUrl" : "",
 	"nextUrl" : "",
 	"firstPage" : {

--- a/input/templates/partials/catalog/results-summary.hbs
+++ b/input/templates/partials/catalog/results-summary.hbs
@@ -1,3 +1,0 @@
-<p class="item-count">
-	{{pagination.currentPage}} {{i18n "catalog:pagination.pageSeparator"}} {{pagination.totalPages}}
-</p>

--- a/input/templates/pop.hbs
+++ b/input/templates/pop.hbs
@@ -68,7 +68,6 @@
                 <div class="custom-select-wrapper">
                   {{> catalog/sort-selector sortSelector=content.sortSelector}}
                 </div>
-                {{> catalog/results-summary pagination=content.pagination}}
               </div>
               <div class="col-xs-4 hidden-xs text-center custom-pagination">
                 <ul class="page-numbers">


### PR DESCRIPTION
@JulianSamarjiev I've removed this small thing that appeared next to the sort selector, since I've seen the search result already has this info, so it would be duplicated. I also never understood exactly the point of having this info there. We can talk it on Monday if you do not agree :)