### PR TITLE
Split watched files between assets and templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@
 
 `grunt publish` to publish the generated site to GitHub Pages (requires $GH_TOKEN)
 
-`grunt release-[patch|minor|major]` to release the current version to the Maven Bintray repository and prepare a new version (requires commercetools-bintray repository ID in Maven's settings.xml)
+`grunt release` to release the current version to the Maven Bintray repository (requires commercetools-bintray repository ID in Maven's settings.xml) and move to the next development version
 
-`grunt clean build maven:install` to install to local maven repository (~/.m2/repository/io/sphere/sphere-sunrise-design)
+`grunt install` to install to local maven repository (~/.m2/repository/io/sphere/sphere-sunrise-design)
 
 Notice you can always add `--verbose` and/or `--debug` to any command in order to obtain more information.
 
@@ -73,13 +73,8 @@ Once the project is built, the generated site is located in the `output/` folder
   - Copy any JS file in `input/assets/js/` to `output/assets/js/`
   - Copy any file in `input/assets/img/` to `output/assets/img/`
   - Copy any file in `input/assets/font/` to `output/assets/font/`
-  - Copy any Handlebars template in `input/templates/` to `output/templates/` (it flattens any directory)
-  - Copy any HTML file in `input/` to `output/` (be careful not to use the same name as a Handlebars template or it will be overwritten)
-
-
-`grunt coffee`
-  - Compile and concatenate any Coffeescript file inside `input/assets/js/` into `output/assets/js/coffee.js`
-
+  - Copy any Handlebars template and JSON data in `input/templates/` to `output/templates/`
+  - Copy any YAML file in `locales/` to `output/locales`
 
 `grunt sass`
   - Processes `input/assets/css/main.scss` into `output/assets/css/main.min.css`
@@ -87,5 +82,8 @@ Once the project is built, the generated site is located in the `output/` folder
 `grunt postcss`
   - Adds vendor-prefixed CSS properties to `output/assets/css/main.min.css`
 
-`grunt compile-handlebars`
+`grunt build-assets`
+  - Generates CSS files and copies all other assets from `input/assets/` to `output/assets/`
+
+`grunt build-templates`
   - Generates HTML files from the Handlebars templates and JSON data defined in `input/templates/` and the partial templates defined in `input/templates/partials/` into `output/`

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "grunt": "^0.4.5",
     "grunt-compile-handlebars": "^2.0.0",
     "grunt-contrib-clean": "^0.6.0",
-    "grunt-contrib-coffee": "^0.13.0",
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-sass": "^0.9.2",
     "grunt-contrib-watch": "^0.6.1",

--- a/tasks/i18n.js
+++ b/tasks/i18n.js
@@ -1,0 +1,29 @@
+module.exports = function(grunt) {
+
+  grunt.registerTask('i18next', 'Internationalization init', function() {
+    var done = this.async();
+    var options = this.options({
+      preload: ['en'],
+      lng: 'en',
+      fallbackLng: 'en',
+      getAsync: false,
+      debug: false,
+      ns: {
+        namespaces: ['translations'],
+        defaultNs: 'translations'
+      },
+      resGetPath: 'locales/__lng__/__ns__.yaml'
+    });
+    Handlebars = require('handlebars');
+
+    i18n = require('i18next');
+
+    var yamlSync = require('i18next.yaml');
+    i18n.backend(yamlSync);
+
+    i18n.init(options, function (err, t) {
+      done(true);
+    });
+  });
+  
+};

--- a/tasks/jsonRefs.js
+++ b/tasks/jsonRefs.js
@@ -1,0 +1,84 @@
+module.exports = function(grunt) {
+
+  grunt.registerMultiTask('json-refs', 'Resolves all JSON References and returns a fully resolved equivalent', function() {
+    var done = this.async();
+    // Default task configuration
+    var options = this.options({
+      partials: "input/templates/partials/"
+    });
+    // 'json-refs' configuration
+    var jsonRefsOptions = {
+      location: options.partials
+    };
+
+    var jsonRefs = require('json-refs');
+    var path = require('path');
+
+    var resolvedRefsPromises = this.files
+    .filter(removeInvalidFiles)
+    .filter(removeInexistentFiles)
+    .map(function(file) {
+      // Resolve JSON references
+      var json = grunt.file.readJSON(file.src[0]);
+      return jsonRefs.resolveRefs(json, jsonRefsOptions)
+      .then(function(result) {
+        return writeResolvedFile(file, result);
+      });
+    });
+
+    Promise.all(resolvedRefsPromises)
+    .then(function(result) {
+      done(true);
+    });
+  });
+
+  var removeInvalidFiles = function(file) {
+    if (file.src.length != 1) {
+      grunt.fail.warn("Only a single source file is currently supported.");
+      return false;
+    } else {
+      return true;
+    }
+  };
+
+  var removeInexistentFiles = function(file) {
+    var filepath = file.src[0];
+    if(!grunt.file.exists(filepath)) {
+      grunt.log.warn('Source file "' + filepath + '" not found.');
+      return false;
+    } else {
+      return true;
+    }
+  };
+
+  var writeResolvedFile = function(file, result) {
+    var written = false;
+    parseMetadata(result.metadata);
+    // Write the resolved JSON to a new file
+    written = grunt.file.write(file.dest, stringifyJson(result.resolved, 2));
+    if (written) {
+      grunt.log.debug('File "' + file.dest + '" created');
+    } else {
+      grunt.log.error('File "' + file.dest + '" failed on creation');
+    }
+    return written;
+  };
+
+  var parseMetadata = function(json) {
+    for (var key in json) {
+      if (json.hasOwnProperty(key)) {
+        var value = json[key];
+        if (value.hasOwnProperty("err")) {
+          grunt.log.error(stringifyJson(value, 2));
+        } else {
+          grunt.verbose.writeln(stringifyJson(value, 0));
+        }
+      }
+    }
+  }
+
+  var stringifyJson = function(json, space) {
+    return JSON.stringify(json, null, space);
+  }
+  
+};


### PR DESCRIPTION
@jayS-de @schleichardt 

- Moved i18next and jsonRefs tasks to own files.
- Remove coffeescript task (not used)
- Default release minor
- Split watched files between assets and templates, so now when changing assets it doesn't build templates and viceversa.